### PR TITLE
Hotfix: Reduce K-mode weight and increase Q-mode oversight for creative outputs

### DIFF
--- a/routing/config.routing.json
+++ b/routing/config.routing.json
@@ -24,7 +24,7 @@
   },
   "routing_overrides": [
     { "pattern": "緊急|緊迫|至急", "mode": "hybrid", "weights": { "J": 0.5, "K": 0.2, "Q": 0.3 } },
-    { "pattern": "企画|ブランディング|表現|デザイン", "mode": "parallel", "weights": { "J": 0.4, "K": 0.5, "Q": 0.1 } },
+    { "pattern": "企画|ブランディング|表現|デザイン", "mode": "parallel", "weights": { "J": 0.4, "K": 0.35, "Q": 0.25 } },
     { "pattern": "セキュリティ|法務|倫理|リスク", "mode": "sequential", "weights": { "J": 0.45, "K": 0.15, "Q": 0.4 } }
     ]
 }


### PR DESCRIPTION
## 概要
config.routing.json の "企画|ブランディング|表現|デザイン" パターンに対するモード比率を変更。
Kモードの比率を 0.50 → 0.35 に引き下げ、Qモードを 0.10 → 0.25 に引き上げ。

## 目的
Kモードによる創造的逸脱を抑制し、Qモード監査の介入頻度を増やすことで短期的なリスク低減を図る。

## 変更内容
- weights: { "J": 0.4, "K": 0.5, "Q": 0.1 }  
  → weights: { "J": 0.4, "K": 0.35, "Q": 0.25 }

## 影響範囲
- creative系パターンの出力傾向
- Qモード監査の強化
- Kモード出力の一時的抑制

## リスク
- Kモードの創造性が短期的に制約される可能性あり
- 長期運用時には恒久対策（役割分離強化・週次レビュー導入）が必要